### PR TITLE
fix: make tests compatible with aiohttp 3.10

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,5 +3,5 @@ import aiohttp
 from anova_wifi import AnovaApi
 
 
-def test_can_create() -> None:
+async def test_can_create() -> None:
     AnovaApi(aiohttp.ClientSession(), "", "")


### PR DESCRIPTION
Closes: #58 