### PR TITLE
fix: send websocket heartbeat to keep connection alive

### DIFF
--- a/src/anova_wifi/websocket_handler.py
+++ b/src/anova_wifi/websocket_handler.py
@@ -17,6 +17,11 @@ from .web_socket_containers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Anova's server never sends anything when a device is idle, so without a
+# heartbeat aiohttp has no way to detect a connection that has died silently
+# (e.g. a NAT/router timeout) instead of via a clean close frame.
+WEBSOCKET_HEARTBEAT_SECONDS = 30
+
 
 class AnovaWebsocketHandler:
     def __init__(self, firebase_jwt: str, jwt: str, session: ClientSession):
@@ -30,7 +35,9 @@ class AnovaWebsocketHandler:
 
     async def connect(self) -> None:
         try:
-            self.ws = await self.session.ws_connect(self.url)
+            self.ws = await self.session.ws_connect(
+                self.url, heartbeat=WEBSOCKET_HEARTBEAT_SECONDS
+            )
         except WebSocketError as ex:
             raise WebsocketFailure("Failed to connect to the websocket") from ex
         self._message_listener = asyncio.ensure_future(self.message_listener())

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -1,0 +1,23 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from anova_wifi.websocket_handler import (
+    WEBSOCKET_HEARTBEAT_SECONDS,
+    AnovaWebsocketHandler,
+)
+
+
+@pytest.mark.asyncio
+async def test_connect_passes_heartbeat_to_ws_connect() -> None:
+    """Without a heartbeat, aiohttp can't detect a silently dead connection."""
+    session = AsyncMock()
+    handler = AnovaWebsocketHandler(
+        firebase_jwt="firebase_jwt", jwt="jwt", session=session
+    )
+
+    await handler.connect()
+
+    session.ws_connect.assert_awaited_once_with(
+        handler.url, heartbeat=WEBSOCKET_HEARTBEAT_SECONDS
+    )


### PR DESCRIPTION
## Problem

Anova's device-list websocket only ever pushes data when something changes — it never sends anything while a device is idle. `AnovaWebsocketHandler.connect()` calls `session.ws_connect()` without a `heartbeat`, so aiohttp never proactively pings the server either.

That means if the underlying TCP connection dies silently — a NAT/router idle timeout, an ISP hiccup, anything that doesn't send a clean WebSocket close frame — the `async for msg in self.ws:` loop in `message_listener()` just hangs forever. The task backing it never completes and never raises, so nothing downstream (e.g. Home Assistant) ever learns the connection is dead. The only way to get updates flowing again is to manually tear down and recreate the integration, forcing a brand new websocket.

This is reproducible in the wild: a Home Assistant instance left running overnight had its anova entities frozen for over a day with zero log output (not even debug-level), confirming the websocket had gone silent rather than erroring.

## Fix

Pass `heartbeat=30` to `ws_connect()`. This makes aiohttp send a ping every 30s, which keeps the connection alive end-to-end through routers/NAT that would otherwise let an idle connection go stale.

The goal: a device that's been idle for a long stretch should still update in real time the moment something changes, without anyone having to reload the integration to force a fresh websocket. This PR achieves that.

## Testing

Added `tests/test_websocket_handler.py::test_connect_passes_heartbeat_to_ws_connect`, asserting `ws_connect` is awaited with the heartbeat argument.

I also patched this into a live Home Assistant instance and left it running for ~19 hours without ever restarting the integration. The same single websocket connection (established once, at startup) stayed alive throughout, including through stretches of 6-8+ hours with no data to push, and continued delivering live pushed updates the whole time — exactly the real-time-after-long-idle behavior this fix is meant to provide.