### PR TITLE
chore: modernize semantic-release to match python-roborock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,33 +61,85 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # Test semantic-release configuration on PR branches
+  test-release:
+    name: Test Semantic Release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Git for Semantic Release Testing
+        run: |
+          # Setup a temp branch to test
+          git checkout -B temp-main-branch
+          git merge ${{ github.event.pull_request.head.sha }} --no-edit
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+      - name: Test Semantic Release (No-op)
+        id: test-release
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          changelog: true
+          # Use noop mode to test without making changes
+          no_operation_mode: true
+      - name: Test Semantic Release (Dry Run)
+        id: test-release-dry
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          changelog: true
+          # Use dry run mode to test without committing
+          commit: false
+          tag: false
+          push: false
+          vcs_release: false
+
   release:
     runs-on: ubuntu-latest
-    environment: release
     needs:
       - test
       - lint
       - commitlint
+    concurrency: release
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+      actions: write
+      packages: write
+    environment:
+      name: release
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      # Run semantic release:
-      # - Update CHANGELOG.md
-      # - Update version in code
-      # - Create git tag
-      # - Create GitHub release
-      # - Publish to PyPI
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.34.6
-        if: github.ref == 'refs/heads/main'
+        id: release
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          changelog: true
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.13.0
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'
+        with:
+          packages-dir: dist
+          print-hash: true
+          verbose: true
+
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/publish-action@v10.5.3
+        if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@v7.34.6
-        if: github.ref_name != 'main'
-        with:
-          additional_options: --noop
+          tag: ${{ steps.release.outputs.tag }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,4 +101,3 @@ allowed_tags = [
     "fix",
     "refactor",
 ]
-major_tags = ["refactor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,19 @@ pytest-asyncio = ">0.21.0"
 
 [tool.semantic_release]
 branch = "main"
-version_toml = "pyproject.toml:tool.poetry.version"
-version_variable = "src/anova_wifi/__init__.py:__version__"
+version_toml = ["pyproject.toml:tool.poetry.version"]
+version_variables = ["src/anova_wifi/__init__.py:__version__"]
 build_command = "pip install poetry && poetry build"
+changelog_file = "CHANGELOG.md"
+commit = true
+
+[tool.semantic_release.branches.main]
+match = "main"
+prerelease = false
+
+[tool.semantic_release.branches.temp-main-branch]
+match = "temp-main-branch"
+prerelease = false
 
 [tool.pytest.ini_options]
 addopts = "-v -Wdefault --cov=anova_wifi --cov-report=term-missing:skip-covered"
@@ -85,17 +95,10 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [
-    "build",
     "chore",
-    "ci",
     "docs",
     "feat",
     "fix",
-    "perf",
-    "style",
     "refactor",
-    "test",
 ]
-minor_tags = ["feat"]
-patch_tags = ["fix", "perf"]
-major_tags = ["refator"]
+major_tags = ["refactor"]


### PR DESCRIPTION
Updates the release pipeline to match what we run on [python-roborock](https://github.com/Python-roborock/python-roborock). The old flow used the deprecated `relekang/python-semantic-release@v7.34.6`, which is also why the two stuck dependabot PRs (#71, #72) trying to bump it to 9.9.0 never went anywhere.

## What changed

**`.github/workflows/ci.yml`**
- Upgrade to `python-semantic-release/python-semantic-release@v10.5.3`.
- New `test-release` job: on every PR it merges the PR head into a `temp-main-branch` and runs semantic-release in **no-op** and **dry-run** modes, so we validate the next-version/changelog computation before merging.
- `release` job now:
  - gates on `github.ref == 'refs/heads/main'` with `concurrency: release`,
  - declares explicit `permissions` (incl. `id-token: write`),
  - publishes to **PyPI** via `pypa/gh-action-pypi-publish@v1.13.0` (trusted publishing — no token),
  - publishes the **GitHub release** via `python-semantic-release/publish-action@v10.5.3`,
  - both publish steps are gated on `steps.release.outputs.released == 'true'`.

**`pyproject.toml` `[tool.semantic_release]`**
- List-form `version_toml` / `version_variables`, added `changelog_file` and `commit = true`.
- Added `main` / `temp-main-branch` branch config blocks (the latter powers the PR dry-run).
- `commit_parser_options` aligned with python-roborock (`allowed_tags` + `major_tags`), which also fixes the pre-existing `"refator"` typo that meant major bumps never fired.

## ⚠️ Repo settings needed before this can release
These match the python-roborock setup but must exist on this repo:
1. **`GH_TOKEN` secret** — the `release` step uses `secrets.GH_TOKEN` (a PAT) instead of the default `GITHUB_TOKEN` so the release commit/tag can push to a protected `main`.
2. **PyPI trusted publishing** — configure a Trusted Publisher on PyPI for `anova-wifi` pointing at this repo's `release` environment (replaces the old `PYPI_TOKEN`). If you'd rather keep token auth, say so and I'll switch the publish step to `password: ${{ secrets.PYPI_TOKEN }}`.

Note: `major_tags = ["refactor"]` means `refactor:` commits trigger a **major** bump (same as python-roborock). Flag it if you'd prefer different semantics here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)