### PR TITLE
fix: parse A7 timer state

### DIFF
--- a/src/anova_wifi/web_socket_containers.py
+++ b/src/anova_wifi/web_socket_containers.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import Any, Callable
 
@@ -342,22 +343,65 @@ def build_a3_payload(apc_response: dict[str, Any]) -> APCUpdate:
     return APCUpdate(binary_sensors, sensors)
 
 
+def _parse_anova_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
+    return datetime.fromisoformat(value)
+
+
 def build_a6_a7_payload(apc_response: dict[str, Any]) -> APCUpdate:
     system_info = apc_response["systemInfo"]
     firmware_version = system_info["firmwareVersion"]
     mode = apc_response["state"]["mode"]
     nodes = apc_response["nodes"]
+    timer = nodes["timer"]
+    timer_mode = timer.get("mode")
+    cook = apc_response.get("cook") or {}
+    active_stage_mode = cook.get("activeStageMode")
+    cook_time = int(timer.get("initial") or 0)
+    cook_time_remaining = 0
+
+    if mode == "cook":
+        if timer_mode == "completed":
+            state = AnovaState.timer_expired
+            cook_time_remaining = 0
+        elif active_stage_mode == "entering":
+            state = AnovaState.preheating
+            cook_time_remaining = cook_time
+        elif timer_mode == "running":
+            state = AnovaState.cooking
+            started_at = _parse_anova_timestamp(timer.get("startedAtTimestamp"))
+            updated_at = _parse_anova_timestamp(apc_response.get("updatedTimestamp"))
+            if started_at is not None and updated_at is not None:
+                elapsed = int((updated_at - started_at).total_seconds())
+                cook_time_remaining = max(0, cook_time - elapsed)
+            else:
+                cook_time_remaining = cook_time
+        else:
+            state = AnovaState.maintaining
+            cook_time_remaining = cook_time
+    else:
+        state = AnovaState.no_state
+
     sensors = APCUpdateSensor(
         firmware_version=firmware_version,
         mode=mode,
+        state=state.name,
         water_temperature=float(nodes["waterTemperatureSensor"]["current"]["celsius"]),
         target_temperature=float(
             nodes["waterTemperatureSensor"]["setpoint"]["celsius"]
         ),
-        cook_time=int(nodes["timer"]["initial"]),
+        cook_time=cook_time,
+        cook_time_remaining=cook_time_remaining,
     )
     binary_sensors = APCUpdateBinary(
         cooking=bool(mode == "cook"),
+        preheating=bool(state == AnovaState.preheating),
+        maintaining=bool(
+            state == AnovaState.maintaining or state == AnovaState.timer_expired
+        ),
         water_level_low=bool(nodes["lowWater"]["warning"]),
         water_level_critical=bool(nodes["lowWater"]["empty"]),
     )

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from anova_wifi.web_socket_containers import (
     AnovaA3State,
     AnovaState,
@@ -33,13 +35,71 @@ def test_a4_payload():
 def test_a7_payload():
     resp = build_a6_a7_payload(A7_MESSAGE["payload"]["state"])
     assert resp.sensor.mode == "idle"
+    assert resp.sensor.state == AnovaState.no_state.name
     assert resp.sensor.cook_time == 36000
+    assert resp.sensor.cook_time_remaining == 0
+    assert resp.binary_sensor.cooking is False
+    assert resp.binary_sensor.preheating is False
+    assert resp.binary_sensor.maintaining is False
 
 
 def test_a7_cooking():
     resp = build_a6_a7_payload(A7_COOKING["payload"]["state"])
     assert resp.sensor.mode == "cook"
+    assert resp.sensor.state == AnovaState.cooking.name
     assert resp.sensor.cook_time == 1200
+    assert resp.sensor.cook_time_remaining == 1154
+    assert resp.binary_sensor.cooking is True
+    assert resp.binary_sensor.preheating is False
+    assert resp.binary_sensor.maintaining is False
+
+
+def test_a7_preheating():
+    message = deepcopy(A7_COOKING)
+    state = message["payload"]["state"]
+    state["nodes"]["timer"]["mode"] = "running"
+    state["cook"]["activeStageMode"] = "entering"
+
+    resp = build_a6_a7_payload(state)
+    assert resp.sensor.mode == "cook"
+    assert resp.sensor.state == AnovaState.preheating.name
+    assert resp.sensor.cook_time == 1200
+    assert resp.sensor.cook_time_remaining == 1200
+    assert resp.binary_sensor.cooking is True
+    assert resp.binary_sensor.preheating is True
+    assert resp.binary_sensor.maintaining is False
+
+
+def test_a7_timer_expired():
+    message = deepcopy(A7_COOKING)
+    state = message["payload"]["state"]
+    state["nodes"]["timer"]["mode"] = "completed"
+    state["cook"]["activeStageMode"] = "running"
+
+    resp = build_a6_a7_payload(state)
+    assert resp.sensor.mode == "cook"
+    assert resp.sensor.state == AnovaState.timer_expired.name
+    assert resp.sensor.cook_time == 1200
+    assert resp.sensor.cook_time_remaining == 0
+    assert resp.binary_sensor.cooking is True
+    assert resp.binary_sensor.preheating is False
+    assert resp.binary_sensor.maintaining is True
+
+
+def test_a7_cooking_without_timestamps():
+    message = deepcopy(A7_COOKING)
+    state = message["payload"]["state"]
+    state["nodes"]["timer"].pop("startedAtTimestamp")
+    state.pop("updatedTimestamp")
+
+    resp = build_a6_a7_payload(state)
+    assert resp.sensor.mode == "cook"
+    assert resp.sensor.state == AnovaState.cooking.name
+    assert resp.sensor.cook_time == 1200
+    assert resp.sensor.cook_time_remaining == 1200
+    assert resp.binary_sensor.cooking is True
+    assert resp.binary_sensor.preheating is False
+    assert resp.binary_sensor.maintaining is False
 
 
 def test_a6_payload():


### PR DESCRIPTION
## Summary

Fix A7 timer/state parsing in the shared A6/A7 websocket payload parser.

The A7 websocket payload already contains the required timer and cook stage data, but the current parser does not expose it through the existing sensor model.

This change maps A7 timer/cook state into the existing fields:

- `nodes.timer.mode = completed` → `AnovaState.timer_expired`
- `cook.activeStageMode = entering` → `AnovaState.preheating`
- `nodes.timer.mode = running` → `AnovaState.cooking`
- `state.mode != cook` → `AnovaState.no_state`

It also populates:

- `sensor.state`
- `sensor.cook_time_remaining`
- `binary_sensor.preheating`
- `binary_sensor.maintaining`

The parser function is shared for A6/A7 in the current codebase, but this change was tested with a real A7 device only.

## Testing

Tested locally with: `pytest tests/test_containers.py`

Result: 8 passed

Also tested locally in Home Assistant with a real A7 device. After applying the patch, the existing State and Cook Time Remaining sensors appeared and updated correctly.