### PR TITLE
feat: support Personal Access Token authentication

### DIFF
--- a/src/anova_wifi/parser.py
+++ b/src/anova_wifi/parser.py
@@ -19,19 +19,41 @@ class AnovaApi:
     def __init__(
         self,
         session: aiohttp.ClientSession,
-        username: str,
-        password: str,
+        username: str | None = None,
+        password: str | None = None,
+        *,
+        personal_access_token: str | None = None,
     ) -> None:
-        """Creates an anova api class"""
+        """Creates an anova api class.
+
+        Provide either a personal_access_token (see
+        developer.anovaculinary.com/docs/devices/wifi/personal-access-tokens)
+        or a username/password, not both.
+        """
+        if personal_access_token is not None:
+            if username is not None or password is not None:
+                raise ValueError(
+                    "Provide either personal_access_token or username/password, not both."
+                )
+        elif username is None or password is None:
+            raise ValueError(
+                "Provide either personal_access_token, or both username and password."
+            )
         self.session = session
         self.username = username
         self.password = password
+        self._personal_access_token = personal_access_token
         self.jwt: str | None = None
         self._firebase_jwt: str | None = None
         self.websocket_handler: AnovaWebsocketHandler | None = None
 
     async def authenticate(self) -> bool:
-        """Auth with Firebase server"""
+        """Auth with Firebase server, or use the configured Personal Access Token directly."""
+        if self._personal_access_token is not None:
+            self._firebase_jwt = self._personal_access_token
+            self.jwt = self._personal_access_token
+            return True
+
         # Code loving yoinked from https://github.com/ammarzuberi/pyanova-api/blob/master/anova/AnovaCooker.py
         firebase_req_data = {
             "email": self.username,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,44 @@
 import aiohttp
+import pytest
 
 from anova_wifi import AnovaApi
+
+pytestmark = pytest.mark.asyncio
 
 
 async def test_can_create() -> None:
     AnovaApi(aiohttp.ClientSession(), "", "")
+
+
+async def test_can_create_with_personal_access_token() -> None:
+    AnovaApi(aiohttp.ClientSession(), personal_access_token="anova-abc123")
+
+
+async def test_requires_credentials() -> None:
+    with pytest.raises(ValueError):
+        AnovaApi(aiohttp.ClientSession())
+
+
+async def test_rejects_both_pat_and_username_password() -> None:
+    with pytest.raises(ValueError):
+        AnovaApi(
+            aiohttp.ClientSession(),
+            "user",
+            "pass",
+            personal_access_token="anova-abc123",
+        )
+
+
+async def test_rejects_username_without_password() -> None:
+    with pytest.raises(ValueError):
+        AnovaApi(aiohttp.ClientSession(), username="user")
+
+
+async def test_authenticate_with_personal_access_token_skips_firebase() -> None:
+    api = AnovaApi(aiohttp.ClientSession(), personal_access_token="anova-abc123")
+
+    result = await api.authenticate()
+
+    assert result is True
+    assert api.jwt == "anova-abc123"
+    assert api._firebase_jwt == "anova-abc123"


### PR DESCRIPTION
## Why

Per Anova's own docs (developer.anovaculinary.com/docs/devices/wifi/personal-access-tokens), Personal Access Tokens are the preferred authentication method for the Wi-Fi device API — a PAT is used directly as the websocket token with no Firebase exchange needed, is individually revocable without touching the account password, and doesn't depend on Google's Firebase Identity API at all.

## What

- `AnovaApi` now accepts an optional `personal_access_token` keyword argument as an alternative to `username`/`password`. Passing one skips the Firebase authenticate() round-trips entirely and uses the token directly.
- Enforces that exactly one auth method is provided (raises `ValueError` otherwise).
- Left username/password support fully intact and unchanged — generating a PAT requires opening the Anova Oven app specifically (even for Sous Vide-only users, per the docs), which is real friction for casual users. Password auth stays the simpler default path; PAT is there for anyone who wants the more secure option.

## Also

Fixed `tests/test_parser.py` missing `pytestmark = pytest.mark.asyncio` — its one existing test was silently a no-op (pytest was skipping the async function body entirely) before this fix, which I needed working to add the new PAT tests in the same file.